### PR TITLE
12.0 CI

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -43,7 +43,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.*" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="21.*" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <VersionPrefix>11.2.2</VersionPrefix>
+    <TargetFramework>net6.0</TargetFramework>
+    <VersionPrefix>12.0.0</VersionPrefix>
     <AssemblyName>FluentValidation.AspNetCore</AssemblyName>
     <PackageId>FluentValidation.AspNetCore</PackageId>
     <Product>FluentValidation.AspNetCore</Product>
     <Description>AspNetCore integration for FluentValidation</Description>
     <PackageReleaseNotes>
-FluentValidation 11 is a major release. Please read the upgrade guide at https://docs.fluentvalidation.net/en/latest/upgrading-to-11.html
+FluentValidation 12 is a major release. Please read the upgrade guide at https://docs.fluentvalidation.net/en/latest/upgrading-to-12.html
 
 Full release notes can be found at https://github.com/FluentValidation/FluentValidation.AspNetCore/releases
     </PackageReleaseNotes>
@@ -29,7 +29,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <NeutralLanguage>en</NeutralLanguage>
     <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)/../FluentValidation-Release.snk</AssemblyOriginatorKeyFile>
     <PackageOutputPath>$(MSBuildProjectDirectory)/../../.build/packages</PackageOutputPath>
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <EnablePackageValidation>false</EnablePackageValidation>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(Configuration)'=='Release'">true</ContinuousIntegrationBuild>
@@ -42,8 +42,8 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.*" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
+    <PackageReference Include="FluentValidation" Version="12.*" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -43,7 +43,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.*" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="21.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -19,9 +19,6 @@
 namespace FluentValidation.AspNetCore;
 
 using System;
-using System.Collections.Generic;
-using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Auto-validation configuration.
@@ -46,13 +43,13 @@ public class FluentValidationAutoValidationConfiguration {
 	/// <summary>
 	/// The type of validator factory to use. Uses the ServiceProviderValidatorFactory by default.
 	/// </summary>
-	[Obsolete("IValidatorFactory and its implementors are deprecated. Please use the Service Provider directly. For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
+	[Obsolete("IValidatorFactory and its implementors are deprecated and will be removed in FluentValidation 13. Please use the Service Provider directly. For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
 	public Type ValidatorFactoryType { get; set; }
 
 	/// <summary>
 	/// The validator factory to use. Uses the ServiceProviderValidatorFactory by default.
 	/// </summary>
-	[Obsolete("IValidatorFactory and its implementors are deprecated. Please use the Service Provider directly. For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
+	[Obsolete("IValidatorFactory and its implementors are deprecated and will be removed in FluentValidation 13. Please use the Service Provider directly. For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
 	public IValidatorFactory ValidatorFactory { get; set; }
 
 	/// <summary>
@@ -60,120 +57,4 @@ public class FluentValidationAutoValidationConfiguration {
 	/// Setting this to true will disable DataAnnotations and only run FluentValidation.
 	/// </summary>
 	public bool DisableDataAnnotationsValidation { get; set; }
-}
-
-/// <summary>
-/// FluentValidation asp.net core configuration
-/// </summary>
-public class FluentValidationMvcConfiguration : FluentValidationAutoValidationConfiguration {
-	private readonly IServiceCollection _services;
-
-	[Obsolete]
-	public FluentValidationMvcConfiguration(ValidatorConfiguration validatorOptions) {
-#pragma warning disable CS0618
-		ValidatorOptions = validatorOptions;
-#pragma warning restore CS0618
-	}
-
-	internal FluentValidationMvcConfiguration(ValidatorConfiguration validatorOptions, IServiceCollection services) {
-		_services = services;
-#pragma warning disable CS0618
-		ValidatorOptions = validatorOptions;
-#pragma warning restore CS0618
-	}
-
-	/// <summary>
-	/// Options that are used to configure all validators.
-	/// </summary>
-	[Obsolete("Global options should be set using the static ValidatorOptions.Global instead.")]
-	public ValidatorConfiguration ValidatorOptions { get; private set; }
-
-	/// <summary>
-	/// Enables or disables localization support within FluentValidation
-	/// </summary>
-	[Obsolete("Set the static ValidatorOptions.Global.LanguageManager.Enabled property instead.")]
-	public bool LocalizationEnabled {
-		get => ValidatorOptions.LanguageManager.Enabled;
-		set => ValidatorOptions.LanguageManager.Enabled = value;
-	}
-
-	internal bool ClientsideEnabled = true;
-	internal Action<FluentValidationClientModelValidatorProvider> ClientsideConfig = x => {};
-
-	/// <summary>
-	/// Whether automatic server-side validation should be enabled (default true).
-	/// </summary>
-	public bool AutomaticValidationEnabled { get; set; } = true;
-
-	/// <summary>
-	/// Registers all validators derived from AbstractValidator within the assembly containing the specified type
-	/// </summary>
-	/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
-	/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-	/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
-	[Obsolete("RegisterValidatorsFromAssemblyContaining is deprecated. Call services.AddValidatorsFromAssemblyContaining<T> instead, which has the same effect. See https://github.com/FluentValidation/FluentValidation/issues/1963")]
-	public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining<T>(Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
-		return RegisterValidatorsFromAssemblyContaining(typeof(T), filter, lifetime, includeInternalTypes);
-	}
-
-	/// <summary>
-	/// Registers all validators derived from AbstractValidator within the assembly containing the specified type
-	/// </summary>
-	/// <param name="type">The type that indicates which assembly that should be scanned</param>
-	/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
-	/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-	/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
-	[Obsolete("RegisterValidatorsFromAssemblyContaining is deprecated. Call services.AddValidatorsFromAssemblyContaining instead, which has the same effect. See https://github.com/FluentValidation/FluentValidation/issues/1963")]
-	public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining(Type type, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
-		return RegisterValidatorsFromAssembly(type.Assembly, filter, lifetime, includeInternalTypes);
-	}
-
-	/// <summary>
-	/// Registers all validators derived from AbstractValidator within the specified assembly
-	/// </summary>
-	/// <param name="assembly">The assembly to scan</param>
-	/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
-	/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-	/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
-	[Obsolete("RegisterValidatorsFromAssembly is deprecated. Call services.AddValidatorsFromAssembly instead, which has the same effect. See https://github.com/FluentValidation/FluentValidation/issues/1963")]
-	public FluentValidationMvcConfiguration RegisterValidatorsFromAssembly(Assembly assembly, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
-		_services.AddValidatorsFromAssembly(assembly, lifetime, filter, includeInternalTypes);
-
-#pragma warning disable CS0618
-		ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
-#pragma warning restore CS0618
-		return this;
-	}
-
-	/// <summary>
-	/// Registers all validators derived from AbstractValidator within the specified assemblies
-	/// </summary>
-	/// <param name="assemblies">The assemblies to scan</param>
-	/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
-	/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-	/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
-	[Obsolete("RegisterValidatorsFromAssemblies is deprecated. Call services.AddValidatorsFromAssemblies instead, which has the same effect. See https://github.com/FluentValidation/FluentValidation/issues/1963")]
-	public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
-		_services.AddValidatorsFromAssemblies(assemblies, lifetime, filter, includeInternalTypes);
-
-#pragma warning disable CS0618
-		ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
-#pragma warning restore CS0618
-		return this;
-	}
-
-	/// <summary>
-	/// Configures clientside validation support
-	/// </summary>
-	/// <param name="clientsideConfig"></param>
-	/// <param name="enabled">Whether clientside validation integration is enabled</param>
-	/// <returns></returns>
-	[Obsolete("ConfigureClientsideValidation is deprecated and will be removed in a future release. To configure client-side validation call services.AddFluentValidationClientsideAdapters(config => ...) instead. For details see https://github.com/FluentValidation/FluentValidation/issues/1965")]
-	public FluentValidationMvcConfiguration ConfigureClientsideValidation(Action<FluentValidationClientModelValidatorProvider> clientsideConfig=null, bool enabled=true) {
-		if (clientsideConfig != null) {
-			ClientsideConfig = clientsideConfig;
-		}
-		ClientsideEnabled = enabled;
-		return this;
-	}
 }

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
@@ -30,74 +30,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 public static class FluentValidationMvcExtensions {
-	/// <summary>
-	///     Adds Fluent Validation services to the specified
-	///     <see cref="T:Microsoft.Extensions.DependencyInjection.IMvcBuilder" />.
-	/// </summary>
-	/// <returns>
-	///     An <see cref="T:Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder" /> that can be used to further configure the
-	///     MVC services.
-	/// </returns>
-	/// <remarks>
-	///		Calling AddFluentValidation() is deprecated. Call <c>services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters()</c> instead, which has the same effect. For details see <see href="https://github.com/FluentValidation/FluentValidation/issues/1965"/>.
-	/// </remarks>
-	[Obsolete("Calling AddFluentValidation() is deprecated. Call services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters() instead, which has the same effect. For details see https://github.com/FluentValidation/FluentValidation/issues/1965")]
-	public static IMvcCoreBuilder AddFluentValidation(this IMvcCoreBuilder mvcBuilder, Action<FluentValidationMvcConfiguration> configurationExpression = null) {
-		mvcBuilder.Services.AddFluentValidation(configurationExpression);
-		return mvcBuilder;
-	}
-
-	/// <summary>
-	///     Adds Fluent Validation services to the specified
-	///     <see cref="T:Microsoft.Extensions.DependencyInjection.IMvcBuilder" />.
-	/// </summary>
-	/// <returns>
-	///     An <see cref="T:Microsoft.Extensions.DependencyInjection.IMvcBuilder" /> that can be used to further configure the
-	///     MVC services.
-	/// </returns>
-	/// <remarks>
-	///		Calling AddFluentValidation() is deprecated. Call <c>services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters()</c> instead, which has the same effect. For details see <see href="https://github.com/FluentValidation/FluentValidation/issues/1965"/>.
-	/// </remarks>
-	[Obsolete("Calling AddFluentValidation() is deprecated. Call services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters() instead, which has the same effect. For details see https://github.com/FluentValidation/FluentValidation/issues/1965")]
-	public static IMvcBuilder AddFluentValidation(this IMvcBuilder mvcBuilder, Action<FluentValidationMvcConfiguration> configurationExpression = null) {
-		mvcBuilder.Services.AddFluentValidation(configurationExpression);
-		return mvcBuilder;
-	}
 
 #pragma warning disable CS0618
-	/// <summary>
-	///     Adds Fluent Validation services to the specified
-	///     <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
-	/// </summary>
-	/// <returns>
-	///     A reference to this instance after the operation has completed.
-	/// </returns>
-	/// <remarks>
-	///		Calling AddFluentValidation() is deprecated. Call <c>services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters()</c> instead, which has the same effect. For details see <see href="https://github.com/FluentValidation/FluentValidation/issues/1965"/>.
-	/// </remarks>
-	[Obsolete("Calling AddFluentValidation() is deprecated. Call services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters() instead, which has the same effect. For details see https://github.com/FluentValidation/FluentValidation/issues/1965")]
-	public static IServiceCollection AddFluentValidation(this IServiceCollection services, Action<FluentValidationMvcConfiguration> configurationExpression = null) {
-		var config = new FluentValidationMvcConfiguration(ValidatorOptions.Global, services);
-		configurationExpression?.Invoke(config);
-
-		services.AddSingleton(config.ValidatorOptions);
-
-		if (config.AutomaticValidationEnabled) {
-			services.AddFluentValidationAutoValidation(cfg => {
-				cfg.DisableDataAnnotationsValidation = config.DisableDataAnnotationsValidation;
-				cfg.ImplicitlyValidateChildProperties = config.ImplicitlyValidateChildProperties;
-				cfg.ImplicitlyValidateRootCollectionElements = config.ImplicitlyValidateRootCollectionElements;
-				cfg.ValidatorFactory = config.ValidatorFactory;
-				cfg.ValidatorFactoryType = config.ValidatorFactoryType;
-			});
-		}
-
-		if (config.ClientsideEnabled) {
-			services.AddFluentValidationClientsideAdapters(config.ClientsideConfig);
-		}
-
-		return services;
-	}
 
 	/// <summary>
 	/// Enables integration between FluentValidation and ASP.NET MVC's automatic validation pipeline.

--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -39,7 +39,8 @@ public class ClientsideMessageTester : IClassFixture<WebAppFixture> {
 
 		_client = webApp.CreateClientWithServices(services => {
 #pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationClientsideAdapters();
 #pragma warning restore CS0618
 			services.AddValidatorsFromAssemblyContaining<TestController>();
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
@@ -288,7 +289,8 @@ public class RazorPagesClientsideMessageTester : IClassFixture<WebAppFixture> {
 	public RazorPagesClientsideMessageTester(WebAppFixture webApp) {
 		_client = webApp.CreateClientWithServices(services => {
 #pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationClientsideAdapters();
 #pragma warning restore CS0618
 			services.AddValidatorsFromAssemblyContaining<TestController>();
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/src/FluentValidation.Tests.AspNetCore/DependencyInjectionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DependencyInjectionTests.cs
@@ -10,8 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 
-#pragma warning disable CS0618
-
 public class DependencyInjectionTests : IClassFixture<WebAppFixture> {
 	private readonly ITestOutputHelper _output;
 	private readonly HttpClient _client;
@@ -22,8 +20,11 @@ public class DependencyInjectionTests : IClassFixture<WebAppFixture> {
 		_output = output;
 		_client = webApp.WithWebHostBuilder(webHostBuilder => {
 				webHostBuilder.ConfigureServices(services => {
-					services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
+					services.AddMvc().AddNewtonsoftJson();
+					services.AddFluentValidationAutoValidation(fv => {
+#pragma warning disable CS0618
 						fv.ImplicitlyValidateChildProperties = false;
+#pragma warning restore CS0618
 					});
 					services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 					services.AddScoped<IValidator<ParentModel>, InjectsExplicitChildValidator>();

--- a/src/FluentValidation.Tests.AspNetCore/DisableAutoValidationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DisableAutoValidationTests.cs
@@ -35,12 +35,8 @@ public class DisableAutoValidationTests : IClassFixture<WebAppFixture> {
 	[Fact]
 	public async Task Disables_automatic_validation() {
 		var client = _webApp.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
-				fv.RegisterValidatorsFromAssemblyContaining<TestController>();
-				fv.AutomaticValidationEnabled = false;
-			});
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddValidatorsFromAssemblyContaining<TestController>();
 		});
 
 		var result = await client.GetErrors("InjectsExplicitChildValidator");
@@ -52,14 +48,8 @@ public class DisableAutoValidationTests : IClassFixture<WebAppFixture> {
 	[Fact]
 	public async Task Disables_automatic_validation_for_implicit_validation() {
 		var client = _webApp.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
-				fv.RegisterValidatorsFromAssemblyContaining<TestController>();
-				fv.ImplicitlyValidateChildProperties = true;
-				// Disabling auto validation supersedes enabling implicit validation.
-				fv.AutomaticValidationEnabled = false;
-			});
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddValidatorsFromAssemblyContaining<TestController>();
 		});
 
 		var result = await client.GetErrors("ImplicitChildValidator");

--- a/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
@@ -15,11 +15,10 @@ public class DisableDataAnnotationsTests : IClassFixture<WebAppFixture> {
 	[Fact]
 	public async Task Disables_data_annotations() {
 		var client = _app.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation(fv => {
 				fv.DisableDataAnnotationsValidation = true;
 			});
-#pragma warning restore CS0618
 			services.AddScoped<IValidator<MultiValidationModel>, MultiValidationValidator>();
 		});
 

--- a/src/FluentValidation.Tests.AspNetCore/GlobalInterceptorTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/GlobalInterceptorTests.cs
@@ -23,9 +23,8 @@ public class GlobalInterceptorTests : IClassFixture<WebAppFixture> {
 			{"Forename", "foo"},
 		};
 		var client = _app.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation();
 			services.AddScoped<IValidator<RulesetTestModel>, RulesetTestValidator>();
 			services.AddSingleton<IValidatorInterceptor, SimplePropertyInterceptor>();
 		});

--- a/src/FluentValidation.Tests.AspNetCore/ImplicitRootCollectionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ImplicitRootCollectionTests.cs
@@ -17,7 +17,8 @@ public class ImplicitRootCollectionTests : IClassFixture<WebAppFixture> {
 
 	private HttpClient CreateClient(bool implicitCollectionValidationEnabled) {
 		return _app.CreateClientWithServices(services => {
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation(fv => {
 				fv.ImplicitlyValidateRootCollectionElements = implicitCollectionValidationEnabled;
 			});
 			services.AddScoped<IValidator<ParentModel>, ParentModelValidator>();

--- a/src/FluentValidation.Tests.AspNetCore/ImplicitValidationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ImplicitValidationTests.cs
@@ -24,7 +24,8 @@ public class ImplicitValidationTests : IClassFixture<WebAppFixture> {
 
 	private HttpClient CreateClient(bool implicitValidationEnabled) {
 		return _app.CreateClientWithServices(services => {
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation(fv => {
 				fv.ImplicitlyValidateChildProperties = implicitValidationEnabled;
 			});
 			services.AddScoped<IValidator<ParentModel>, ParentModelValidator>();

--- a/src/FluentValidation.Tests.AspNetCore/MvcIntegrationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/MvcIntegrationTests.cs
@@ -23,9 +23,8 @@ public class MvcIntegrationTests : IClassFixture<WebAppFixture> {
 		_output = output;
 		_webApp = webApp;
 		_client = webApp.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation();
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 			services.AddScoped<IValidator<TestModel>, TestModelValidator>();
 			services.AddScoped<IValidator<TestModel3>, TestModelValidator3>();

--- a/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
@@ -9,8 +9,6 @@ using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
-
-
 public class RazorPagesTestsWithImplicitValidationDisabled : IClassFixture<WebAppFixture> {
 	private readonly ITestOutputHelper _output;
 	private readonly HttpClient _client;
@@ -20,9 +18,8 @@ public class RazorPagesTestsWithImplicitValidationDisabled : IClassFixture<WebAp
 
 		_output = output;
 		_client = webApp.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation();
 			services.AddScoped<IValidator<TestModel>, TestModelValidator>();
 			services.AddScoped<IValidator<RulesetTestModel>, RulesetTestValidator>();
 			services.AddScoped<IValidator<ClientsideRulesetModel>, ClientsideRulesetValidator>();
@@ -79,11 +76,12 @@ public class RazorPagesTestsWithImplicitValidationEnabled : IClassFixture<WebApp
 
 		_output = output;
 		_client = _client = webApp.CreateClientWithServices(services => {
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation(fv => {
 #pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 				fv.ImplicitlyValidateChildProperties = true;
-			});
 #pragma warning restore CS0618
+			});
 			services.AddScoped<IValidator<TestModel>, TestModelValidator>();
 			services.AddScoped<IValidator<RulesetTestModel>, RulesetTestValidator>();
 			services.AddScoped<IValidator<ClientsideRulesetModel>, ClientsideRulesetValidator>();

--- a/src/FluentValidation.Tests.AspNetCore/ServiceProviderTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ServiceProviderTests.cs
@@ -14,9 +14,8 @@ public class ServiceProviderTests : IClassFixture<WebAppFixture> {
 	public ServiceProviderTests(WebAppFixture webApp) {
 
 		_client = webApp.CreateClientWithServices(services => {
-#pragma warning disable CS0618
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation();
-#pragma warning restore CS0618
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddFluentValidationAutoValidation();
 			services.AddValidatorsFromAssemblyContaining<TestController>();
 		});
 	}

--- a/src/FluentValidation.Tests.AspNetCore/TypeFilterTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TypeFilterTests.cs
@@ -38,9 +38,9 @@ public class TypeFilterTests : IClassFixture<WebAppFixture> {
 	[Fact]
 	public async Task Finds_and_executes_validator() {
 		var client = _webApp.CreateClientWithServices(services => {
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
-				fv.RegisterValidatorsFromAssemblyContaining<TestController>();
-			});
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddValidatorsFromAssemblyContaining<TestController>();
+			services.AddFluentValidationAutoValidation();
 		});
 		var result = await client.GetErrors("InjectsExplicitChildValidator");
 
@@ -52,11 +52,11 @@ public class TypeFilterTests : IClassFixture<WebAppFixture> {
 	[Fact]
 	public async Task Filters_types() {
 		var client = _webApp.CreateClientWithServices(services => {
-			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
-				fv.RegisterValidatorsFromAssemblyContaining<TestController>(scanResult => {
-					return scanResult.ValidatorType != typeof(InjectsExplicitChildValidator);
-				});
+			services.AddMvc().AddNewtonsoftJson();
+			services.AddValidatorsFromAssemblyContaining<TestController>(filter: scanResult => {
+				return scanResult.ValidatorType != typeof(InjectsExplicitChildValidator);
 			});
+			services.AddFluentValidationAutoValidation();
 		});
 
 		var result = await client.GetErrors("InjectsExplicitChildValidator");


### PR DESCRIPTION
Breaking changes to document:

- [ ] Removal of deprecated `IMvcBuilder.AddFluentValidation` methods (https://github.com/FluentValidation/FluentValidation/issues/1963, https://github.com/FluentValidation/FluentValidation/issues/1965)
- [ ] Remove `FluentValidationMvcConfiguration.ValidatorOptions` and `FluentValidationMvcConfiguration.LocalizationEnabled`

Undecided whether I should actually remove Implicit validation or just leave it permanently deprecated & unsupported. 
- [ ] Removal of Implicit Child validation and Implicit Validation of Child Collections (https://github.com/FluentValidation/FluentValidation/issues/1960)